### PR TITLE
fix: Adjust bottom padding in event details card

### DIFF
--- a/app/src/main/res/layout/fragment_event_details.xml
+++ b/app/src/main/res/layout/fragment_event_details.xml
@@ -58,7 +58,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:padding="16dp">
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:paddingTop="16dp"
+                android:paddingBottom="8dp">
 
                 <TextView
                     android:id="@+id/titleTextView"


### PR DESCRIPTION
Reduces the bottom padding within the content area of the event details card from 16dp to 8dp. This change makes the spacing after the 'Join Event' button tighter, addressing your feedback regarding extra space at the end of the card.