### PR TITLE
fix: Ensure event details content area extends to viewport bottom

### DIFF
--- a/app/src/main/res/layout/fragment_event_details.xml
+++ b/app/src/main/res/layout/fragment_event_details.xml
@@ -4,11 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white">
+    android:background="@color/white"
+    android:fillViewport="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
         <ImageView
             android:id="@+id/eventImageView"


### PR DESCRIPTION
Modified `fragment_event_details.xml` to address feedback regarding whitespace at the bottom of the screen when content is short.

Changes:
- Added `android:fillViewport="true"` to the `NestedScrollView`.
- Changed `android:layout_height` of the direct child `ConstraintLayout` (within `NestedScrollView`) from `wrap_content` to `match_parent`.

This ensures that the main content container within the scroll view expands to the full height of the viewport, providing a more continuous appearance and reducing empty space below the content when the event details are not long enough to require scrolling.