### PR TITLE
fix: Refactor event details layout and correct image display

### DIFF
--- a/app/src/main/java/com/example/eventapp/fragments/EventDetailsFragment.java
+++ b/app/src/main/java/com/example/eventapp/fragments/EventDetailsFragment.java
@@ -19,6 +19,7 @@ import com.example.eventapp.models.Event;
 import com.example.eventapp.repository.EventRepository;
 import com.bumptech.glide.Glide;
 
+import android.util.Log; // Added for logging
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 import java.util.Date;
@@ -177,13 +178,29 @@ public class EventDetailsFragment extends Fragment {
 
 
         if (event.getImageBase64() != null && !event.getImageBase64().isEmpty() && getContext() != null) {
-            // Convert base64 to bitmap
-            byte[] decodedString = android.util.Base64.decode(event.getImageBase64(), android.util.Base64.DEFAULT);
-            Glide.with(getContext())
-                .load(decodedString)
-                .placeholder(R.drawable.placeholder_image)
-                .error(R.drawable.error_image)
-                .into(eventImageView);
+            String base64Image = event.getImageBase64();
+            String pureBase64Image = base64Image;
+
+            // Check if the string contains the Base64 prefix
+            if (base64Image.contains(",")) {
+                // Split the string at the comma and take the second part (the actual Base64)
+                pureBase64Image = base64Image.substring(base64Image.indexOf(",") + 1);
+            }
+
+            try {
+                byte[] decodedString = android.util.Base64.decode(pureBase64Image, android.util.Base64.DEFAULT);
+                Glide.with(getContext())
+                    .load(decodedString)
+                    .placeholder(R.drawable.placeholder_image)
+                    .error(R.drawable.error_image) // This error drawable should show if decoding fails or bytes are not an image
+                    .into(eventImageView);
+            } catch (IllegalArgumentException e) {
+                // Log error or handle case where pureBase64Image is not valid Base64
+                Log.e("EventDetailsFragment", "Failed to decode Base64 string", e);
+                Glide.with(getContext())
+                    .load(R.drawable.error_image) // Show error drawable explicitly on decode failure
+                    .into(eventImageView);
+            }
         } else {
             // Load placeholder if no image
             Glide.with(getContext())

--- a/app/src/main/res/layout/fragment_event_details.xml
+++ b/app/src/main/res/layout/fragment_event_details.xml
@@ -46,27 +46,21 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
-        <androidx.cardview.widget.CardView
+        <LinearLayout
             android:id="@+id/eventDetailsCardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="230dp"
-            app:cardCornerRadius="20dp"
-            app:cardElevation="8dp"
-            app:layout_constraintTop_toTopOf="parent">
+            android:orientation="vertical"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="8dp"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginTop="230dp">
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/titleTextView"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:paddingLeft="16dp"
-                android:paddingRight="16dp"
-                android:paddingTop="16dp"
-                android:paddingBottom="8dp">
-
-                <TextView
-                    android:id="@+id/titleTextView"
-                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:textSize="24sp"
                     android:textStyle="bold"
@@ -183,9 +177,7 @@
                     android:background="?attr/colorPrimary"
                     android:textColor="@android:color/white"/>
 
-            </LinearLayout>
-
-        </androidx.cardview.widget.CardView>
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
This commit addresses two main pieces of feedback:
1.  Removes the CardView from the event details page:
    - The LinearLayout previously inside the CardView now directly holds the event details content.
    - This simplifies the layout structure while maintaining the visual positioning of the details.
    - The ID used by the fragment to control visibility of this section has been transferred to the LinearLayout.

2.  Fixes an issue where event images were not displaying:
    - The Base64 image string from the backend includes a data URI prefix (e.g., "data:image/jpeg;base64,").
    - The Android Base64 decoder expects a pure Base64 string.
    - Modified EventDetailsFragment.java to strip this prefix before decoding.
    - Added error handling (try-catch) for Base64 decoding to gracefully manage malformed strings and display an error image if decoding fails.